### PR TITLE
Restore Canary routes on DigitalOcean

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:20.19.4-alpine3.22
+
+WORKDIR /app
+COPY --chown=node:node server.js ./server.js
+COPY --chown=node:node api ./api
+
+ENV NODE_ENV=production
+USER node
+EXPOSE 8080
+CMD ["node", "server.js"]

--- a/scripts/ci.js
+++ b/scripts/ci.js
@@ -14,7 +14,10 @@ const REQUIRED_FILES = [
   'js/canary.js',
   'api/health.js',
   'api/canary/api/v1/errors.js',
+  'server.js',
+  'Dockerfile',
   'scripts/verify-canary.js',
+  'scripts/verify-server.js',
   'scripts/smoke-canary-production.js',
   'favicon.ico',
   'fonts/ClashDisplay-Variable.woff2',
@@ -192,6 +195,9 @@ function main() {
   step('CSS local references resolve', assertCssReferences);
   step('JavaScript parses', assertJavaScriptSyntax);
   step('Canary routes preserve behavior', () => runNodeScript('scripts/verify-canary.js'));
+  step('DigitalOcean server adapter preserves behavior', () =>
+    runNodeScript('scripts/verify-server.js')
+  );
   console.log('timeismoney-splash CI gate passed');
 }
 

--- a/scripts/verify-server.js
+++ b/scripts/verify-server.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const { spawn } = require('node:child_process');
+
+function listen(server) {
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve(server.address().port));
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+async function startApp(environment) {
+  const probe = http.createServer();
+  const port = await listen(probe);
+  await close(probe);
+
+  const child = spawn(process.execPath, ['server.js'], {
+    cwd: new URL('..', `file://${__dirname}/`).pathname,
+    env: {
+      ...process.env,
+      PORT: String(port),
+      NEXT_PUBLIC_SITE_URL: `http://127.0.0.1:${port}`,
+      ...environment,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  let stderr = '';
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk;
+  });
+
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (child.exitCode !== null) {
+      throw new Error(`server exited ${child.exitCode}: ${stderr}`);
+    }
+    try {
+      await fetch(`http://127.0.0.1:${port}/api/health`);
+      return { child, port };
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+  }
+
+  child.kill('SIGTERM');
+  throw new Error(`server did not become ready: ${stderr}`);
+}
+
+async function stopApp(child) {
+  child.kill('SIGTERM');
+  await new Promise((resolve) => child.once('exit', resolve));
+}
+
+async function main() {
+  let received;
+  const canary = http.createServer((request, response) => {
+    let body = '';
+    request.on('data', (chunk) => {
+      body += chunk;
+    });
+    request.on('end', () => {
+      received = {
+        authorization: request.headers.authorization,
+        body: JSON.parse(body),
+      };
+      response.writeHead(202, { 'Content-Type': 'application/json' });
+      response.end('{}');
+    });
+  });
+  const canaryPort = await listen(canary);
+
+  const { child, port } = await startApp({
+    CANARY_API_KEY: 'integration-test-key',
+    CANARY_ENDPOINT: `http://127.0.0.1:${canaryPort}`,
+    CANARY_SERVICE_NAME: 'timeismoney-splash',
+    NODE_ENV: 'production',
+  });
+
+  try {
+    const health = await fetch(`http://127.0.0.1:${port}/api/health`);
+    assert.equal(health.status, 200);
+    assert.equal((await health.json()).dependencies.canary, 'configured');
+
+    const healthHead = await fetch(`http://127.0.0.1:${port}/api/health`, {
+      method: 'HEAD',
+    });
+    assert.equal(healthHead.status, 200);
+    assert.equal(await healthHead.text(), '');
+
+    const healthPost = await fetch(`http://127.0.0.1:${port}/api/health`, {
+      method: 'POST',
+    });
+    assert.equal(healthPost.status, 405);
+
+    const relayGet = await fetch(
+      `http://127.0.0.1:${port}/api/canary/api/v1/errors`
+    );
+    assert.equal(relayGet.status, 405);
+
+    const rejected = await fetch(
+      `http://127.0.0.1:${port}/api/canary/api/v1/errors`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'https://evil.example',
+        },
+        body: JSON.stringify({ message: 'reject me' }),
+      }
+    );
+    assert.equal(rejected.status, 403);
+
+    const accepted = await fetch(
+      `http://127.0.0.1:${port}/api/canary/api/v1/errors`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: `http://127.0.0.1:${port}`,
+          Referer: `http://127.0.0.1:${port}/?token=secret`,
+        },
+        body: JSON.stringify({
+          error_class: 'AdapterTest',
+          message: 'user test@example.com failed with token=secret',
+        }),
+      }
+    );
+    assert.equal(accepted.status, 202);
+    assert.equal(received.authorization, 'Bearer integration-test-key');
+    assert.equal(received.body.service, 'timeismoney-splash');
+    assert.equal(received.body.message.includes('test@example.com'), false);
+    assert.equal(received.body.message.includes('token=secret'), false);
+
+    const missing = await fetch(`http://127.0.0.1:${port}/missing`);
+    assert.equal(missing.status, 404);
+  } finally {
+    await stopApp(child);
+    await close(canary);
+  }
+
+  console.log('timeismoney DigitalOcean server adapter verification passed');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/server.js
+++ b/server.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+'use strict';
+
+const http = require('node:http');
+const health = require('./api/health');
+const relay = require('./api/canary/api/v1/errors');
+
+const routes = new Map([
+  ['/api/health', health],
+  ['/api/canary/api/v1/errors', relay],
+]);
+
+function adaptResponse(response) {
+  response.status = function status(code) {
+    this.statusCode = code;
+    return this;
+  };
+  response.json = function json(body) {
+    if (!this.hasHeader('Content-Type')) {
+      this.setHeader('Content-Type', 'application/json; charset=utf-8');
+    }
+    this.end(JSON.stringify(body));
+    return this;
+  };
+  return response;
+}
+
+const server = http.createServer(async (request, response) => {
+  const pathname = new URL(request.url, 'http://localhost').pathname;
+  const handler = routes.get(pathname);
+  if (!handler) {
+    response.writeHead(404, { 'Content-Type': 'application/json; charset=utf-8' });
+    response.end(JSON.stringify({ error: 'Not found' }));
+    return;
+  }
+
+  try {
+    await handler(request, adaptResponse(response));
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        level: 'error',
+        service: process.env.CANARY_SERVICE_NAME || 'timeismoney-splash',
+        operation: 'request',
+        error: error instanceof Error ? error.message : 'unknown error',
+      })
+    );
+    if (!response.headersSent) {
+      response.writeHead(500, {
+        'Content-Type': 'application/json; charset=utf-8',
+      });
+    }
+    if (!response.writableEnded) {
+      response.end(JSON.stringify({ error: 'Internal server error' }));
+    }
+  }
+});
+
+const port = Number(process.env.PORT || 8080);
+server.listen(port, '0.0.0.0', () => {
+  console.log(JSON.stringify({ level: 'info', service: 'timeismoney-splash', port }));
+});
+
+function shutdown() {
+  server.close(() => process.exit(0));
+}
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);


### PR DESCRIPTION
## Summary
- add a dependency-free Node service adapter for the existing health and Canary relay handlers
- package the adapter for DigitalOcean App Platform without changing the static site
- add request-level integration coverage and wire it into the repo gate

## Proof
- `node scripts/ci.js`
- `docker build -t timeismoney-relay:test .`
- live container `/api/health` returned configured status

## Migration boundary
Vercel remains retained. Deployment and live Canary ingest/readback are tracked by Powder `do-migration-117`; this PR alone does not authorize provider deletion.

Agent: Codex verifier-builder
Agent-Surface: Codex CLI
Agent-Model: openai/gpt-5.5
Agent-Task: do-migration-117
Agent-Context: run-BYp4mvrhh3Cu